### PR TITLE
Remove Node.js references

### DIFF
--- a/bin/build-dev
+++ b/bin/build-dev
@@ -6,6 +6,3 @@ cd "$(dirname "$0")/.."
 
 # Install Python dependencies.
 pip install -e '.[development]'
-
-# Install JavaScript dependencies.
-npm install


### PR DESCRIPTION
This fixes a bug where the `build-dev` command would fail.