### PR TITLE
Make reactives pickleable

### DIFF
--- a/reactives/factory/property.py
+++ b/reactives/factory/property.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Callable, Sequence, TypeVar, Any
+from typing import Callable, Sequence, TypeVar, Any, Dict, Generic
 
 from reactives import scope, is_reactive, assert_reactive, ReactorController, reactive_factory, UnsupportedReactive
 from reactives.factory.type import InstanceAttribute, _InstanceReactorController
@@ -7,15 +7,28 @@ from reactives.factory.type import InstanceAttribute, _InstanceReactorController
 T = TypeVar('T')
 
 
-class _ReactivePropertyReactorController(ReactorController):
-    def __init__(self, reactive_property: '_ReactiveProperty', instance):
+class _ReactivePropertyReactorController(ReactorController, Generic[T]):
+    def __init__(self, instance: T, on_trigger: Sequence[Callable[[T], None]]):
         super().__init__()
-        self._reactive_property = reactive_property
         self._instance = instance
+        self._on_trigger = on_trigger
         self._dependencies = []
 
+    def __getstate__(self) -> Dict[str, Any]:
+        state = super().__getstate__()
+        state['_on_trigger'] = self._on_trigger
+        state['_instance'] = self._instance
+        state['_dependencies'] = self._dependencies
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        super().__setstate__(state)
+        self._on_trigger = state['_on_trigger']
+        self._instance = state['_instance']
+        self._dependencies = state['_dependencies']
+
     def trigger(self) -> None:
-        for on_trigger in self._reactive_property._on_trigger:
+        for on_trigger in self._on_trigger:
             on_trigger(self._instance)
         super().trigger()
 
@@ -28,14 +41,14 @@ class _ReactiveProperty(InstanceAttribute):
         self._on_trigger = on_trigger
 
     def create_instance_attribute_reactor_controller(self, instance) -> ReactorController:
-        return _ReactivePropertyReactorController(self, instance)
+        return _ReactivePropertyReactorController(instance, self._on_trigger)
 
     def __get__(self, instance, owner=None) -> Any:
         if instance is None:
             return self
-        return self.__get__from_instance(instance, owner)
+        return self._get__from_instance(instance, owner)
 
-    def __get__from_instance(self, instance, owner=None):
+    def _get__from_instance(self, instance, owner=None):
         assert_reactive(instance, _InstanceReactorController)
         reactive_instance_attribute = instance.react.getattr(self)
         with scope.collect(reactive_instance_attribute, reactive_instance_attribute.react._dependencies):

--- a/reactives/scope.py
+++ b/reactives/scope.py
@@ -29,7 +29,7 @@ def collect(dependent: Reactive, dependencies: List[ReactorDefinition]) -> None:
 
 def clear(dependent: Reactive, dependencies: List[ReactorDefinition]):
     for dependency in dependencies:
-        dependency.react.shutdown_weakref(dependent)
+        dependency.react.shutdown(dependent)
     dependencies.clear()
 
 
@@ -54,3 +54,12 @@ def register_self(decorated_function: Callable) -> Callable:
         return decorated_function(self, *args, **kwargs)
 
     return _register_self
+
+
+@contextmanager
+def suspend() -> None:
+    global _dependencies
+    original_dependencies = _dependencies
+    _dependencies = None
+    yield
+    _dependencies = original_dependencies

--- a/reactives/tests/reactive/test_function.py
+++ b/reactives/tests/reactive/test_function.py
@@ -1,7 +1,25 @@
+import pickle
 from unittest import TestCase
 
 from reactives import reactive
-from reactives.tests import assert_reactor_called
+from reactives.tests import assert_reactor_called, assert_not_reactor_called
+
+
+class ReactiveFunctionControllerTest(TestCase):
+    @reactive
+    class _Reactive:
+        @reactive
+        def subject(self) -> None:
+            pass
+
+    def test___getstate__(self) -> None:
+        subject = self._Reactive()
+        # Call the function so the instance can lazily instantiate the reactor controller we are testing here.
+        subject.subject()
+        unpickled_subject = pickle.loads(pickle.dumps(subject))
+        with assert_not_reactor_called(subject):
+            with assert_reactor_called(unpickled_subject):
+                unpickled_subject.react.getattr('subject').react.trigger()
 
 
 class ReactiveFunctionTest(TestCase):

--- a/reactives/tests/reactive/test_type.py
+++ b/reactives/tests/reactive/test_type.py
@@ -1,3 +1,5 @@
+import copy
+import pickle
 from unittest import TestCase
 
 from reactives import assert_reactive
@@ -27,6 +29,43 @@ class InstanceReactorControllerTest(TestCase):
 
 
 class ReactiveTypeTest(TestCase):
+    @reactive
+    class Subject:
+        @reactive
+        def subject_function(self) -> None:
+            pass
+
+        @reactive
+        @property
+        def subject_property(self) -> None:
+            return
+
+    @reactive
+    class SubjectWithCopy(Subject):
+        def __copy__(self) -> 'ReactiveTypeTest.SubjectWithCopy':
+            return self.__class__()
+
+    def test_pickle(self) -> None:
+        subject = self.Subject()
+        unpickled_subject = pickle.loads(pickle.dumps(subject))
+        with assert_not_reactor_called(subject):
+            with assert_reactor_called(unpickled_subject):
+                unpickled_subject.react.trigger()
+
+    def test___copy___without___copy__(self) -> None:
+        subject = self.Subject()
+        copied_subject = copy.copy(subject)
+        with assert_not_reactor_called(subject):
+            with assert_reactor_called(copied_subject):
+                copied_subject.react.trigger()
+
+    def test___copy___with___copy__(self) -> None:
+        subject = self.SubjectWithCopy()
+        copied_subject = copy.copy(subject)
+        with assert_not_reactor_called(subject):
+            with assert_reactor_called(copied_subject):
+                copied_subject.react.trigger()
+
     def test_instance_trigger_without_reactors(self) -> None:
         @reactive
         class Subject:

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ SETUP = {
             'autopep8 ~= 1.5',
             'codecov ~= 2.1',
             'coverage ~= 5.5',
+            'dill ~= 0.3.4',
             # flake8 3.8 fails on circular imports caused by string-based type hints.
             'flake8 ~= 3.7.0',
             'nose2 ~= 0.10',


### PR DESCRIPTION
Make reactives copyable/pickleable so their reactor controllers as well as reactors are copied along. Among other things, this allows reactive data to be communicated to other processes.