### PR TITLE
Improve the reactivity checks

### DIFF
--- a/reactives/__init__.py
+++ b/reactives/__init__.py
@@ -13,7 +13,7 @@ T = TypeVar('T')
 
 
 # A reactive has an attribute called "react" containing a ReactorController.
-# See assert_reactive() and isreactive().
+# See assert_reactive() and is_reactive().
 Reactive = Any
 
 
@@ -68,7 +68,7 @@ class ReactorController:
         if isinstance(reactor, weakref.ref):
             reactor = reactor()
 
-        if isreactive(reactor):
+        if is_reactive(reactor):
             yield caller, reactor.react.trigger
             for reactor_reactor in reactor.react._reactors:
                 yield from self._expand_reactor(reactor.react.trigger, reactor_reactor)
@@ -136,15 +136,11 @@ class ReactorController:
 
 
 def assert_reactive(subject, controller_type: Type[ReactorController] = ReactorController) -> None:
-    try:
-        assert isinstance(getattr(subject, 'react'), controller_type)
-    except (AttributeError, AssertionError):
-        raise ValueError('%s is not reactive: %s.react does not exist or is not an instance of %s.' % (
-            subject, subject, controller_type))
+    if not hasattr(subject, 'react'):
+        raise AssertionError(f'{subject} is not reactive: {subject}.react does not exist.')
+    if not isinstance(subject.react, controller_type):
+        raise AssertionError(f'{subject} is not reactive: {subject}.react is not an instance of {controller_type}.')
 
 
-def isreactive(subject, controller_type: Type[ReactorController] = ReactorController) -> bool:
-    with suppress(ValueError):
-        assert_reactive(subject, controller_type)
-        return True
-    return False
+def is_reactive(subject, controller_type: Type[ReactorController] = ReactorController) -> bool:
+    return hasattr(subject, 'react') and isinstance(subject.react, controller_type)

--- a/reactives/collections.py
+++ b/reactives/collections.py
@@ -2,7 +2,7 @@ from contextlib import suppress
 from copy import copy
 from typing import Any, Iterable
 
-from reactives import ReactorController, isreactive, scope
+from reactives import ReactorController, is_reactive, scope
 
 
 class ReactiveDict(dict):
@@ -13,11 +13,11 @@ class ReactiveDict(dict):
             self._wire(value)
 
     def _wire(self, value) -> None:
-        if isreactive(value):
+        if is_reactive(value):
             value.react(self)
 
     def _unwire(self, value) -> None:
-        if isreactive(value):
+        if is_reactive(value):
             value.react.shutdown(self)
 
     def clear(self) -> None:
@@ -122,11 +122,11 @@ class ReactiveList(list):
             self._wire(value)
 
     def _wire(self, value) -> None:
-        if isreactive(value):
+        if is_reactive(value):
             value.react(self)
 
     def _unwire(self, value) -> None:
-        if isreactive(value):
+        if is_reactive(value):
             value.react.shutdown(self)
 
     def append(self, value) -> None:

--- a/reactives/reactive/property.py
+++ b/reactives/reactive/property.py
@@ -1,7 +1,7 @@
 import functools
 from typing import Callable, Sequence, TypeVar, Any
 
-from reactives import scope, isreactive, assert_reactive, ReactorController
+from reactives import scope, is_reactive, assert_reactive, ReactorController
 from reactives.reactive import UnsupportedReactive, reactive_type
 from reactives.reactive.type import InstanceAttribute, _InstanceReactorController
 
@@ -46,7 +46,7 @@ class _ReactiveProperty(InstanceAttribute):
         reactive_instance_attribute = instance.react.getattr(self)
         scope.clear(reactive_instance_attribute, reactive_instance_attribute.react._dependencies)
         self._decorated_property.__set__(instance, value)
-        if isreactive(value):
+        if is_reactive(value):
             reactive_instance_attribute.react._dependencies.append(value)
             value.react.react_weakref(reactive_instance_attribute)
         reactive_instance_attribute.react.trigger()

--- a/reactives/reactive/type.py
+++ b/reactives/reactive/type.py
@@ -1,6 +1,6 @@
 import inspect
 
-from reactives import ReactorController, Reactive, isreactive
+from reactives import ReactorController, Reactive, is_reactive
 from reactives.reactive import reactive_type
 
 
@@ -22,7 +22,7 @@ class _InstanceReactorController(ReactorController):
 
         # Initialize each reactive instance attribute and autowire it. Get the attributes through the class, though, so
         # we can get the actual descriptors.
-        for name, attribute in inspect.getmembers(instance.__class__, self._isreactive):
+        for name, attribute in inspect.getmembers(instance.__class__, self._is_reactive):
             if isinstance(attribute, InstanceAttribute):
                 reactor_controller = attribute.create_instance_attribute_reactor_controller(
                     instance)
@@ -32,8 +32,8 @@ class _InstanceReactorController(ReactorController):
             reactive_attribute.react(instance)
             self._reactive_attributes[name] = self._reactive_attributes[attribute] = reactive_attribute
 
-    def _isreactive(self, attribute) -> bool:
-        if isreactive(attribute):
+    def _is_reactive(self, attribute) -> bool:
+        if is_reactive(attribute):
             return True
 
         if isinstance(attribute, InstanceAttribute):

--- a/reactives/tests/__init__.py
+++ b/reactives/tests/__init__.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 from typing import Union
 
-from reactives import ReactorController, Reactor, Reactive, ReactorDefinition, isreactive, scope
+from reactives import ReactorController, Reactor, Reactive, ReactorDefinition, scope
 
 
 class _Reactive:
@@ -51,7 +51,3 @@ def assert_in_scope(dependency: ReactorDefinition):
     with scope.collect(_Reactive(), dependencies):
         yield
     assert dependency in dependencies
-
-
-def assert_is_reactive(subject):
-    assert isreactive(subject)

--- a/reactives/tests/reactive/test_type.py
+++ b/reactives/tests/reactive/test_type.py
@@ -1,8 +1,9 @@
 from unittest import TestCase
 
+from reactives import assert_reactive
 from reactives.reactive import reactive
 from reactives.reactive.type import _InstanceReactorController
-from reactives.tests import assert_reactor_called, assert_not_reactor_called, assert_is_reactive
+from reactives.tests import assert_reactor_called, assert_not_reactor_called
 
 
 class InstanceReactorControllerTest(TestCase):
@@ -13,7 +14,7 @@ class InstanceReactorControllerTest(TestCase):
             def subject(self):
                 pass
         sut = _InstanceReactorController(Subject())
-        assert_is_reactive(sut.getattr('subject'))
+        assert_reactive(sut.getattr('subject'))
 
     def test_getattr_with_non_existent_reactive_attribute(self) -> None:
         @reactive

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ SETUP = {
             # flake8 3.8 fails on circular imports caused by string-based type hints.
             'flake8 ~= 3.7.0',
             'nose2 ~= 0.10',
+            'parameterized ~= 0.8',
             'setuptools ~= 54.2',
             'twine ~= 3.4',
             'wheel ~= 0.36',


### PR DESCRIPTION
Improve the reactivity checks: consistent naming, more detailed errors, raise `AssertionError` instead of `ValueError`, and reuse these checks in tests.