### PR TITLE
Add Python 3.11 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ jobs:
     strategy:
       matrix:
         include:
+          - name: 'Python 3.11'
+            os: ubuntu-latest
+            python: '3.11'
           - name: 'Python 3.10'
             os: ubuntu-latest
             python: '3.10'
@@ -18,9 +21,6 @@ jobs:
           - name: 'Python 3.8'
             os: ubuntu-latest
             python: '3.8'
-          - name: 'Python 3.7'
-            os: ubuntu-latest
-            python: '3.7'
 
     steps:
       - name: Check out the source code

--- a/bin/test
+++ b/bin/test
@@ -11,7 +11,7 @@ done
 
 # Test the Python code style.
 flake8 --config ./flake8.ini ./reactives
-mypy ./reactives
+mypy
 
 # Run Python tests with coverage.
 coverage erase

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,5 +11,8 @@ ignore_missing_imports = True
 [mypy-graphlib]
 ignore_missing_imports = True
 
+[mypy-graphlib_backport.*]
+ignore_missing_imports = True
+
 [mypy-parameterized]
 ignore_missing_imports = True

--- a/reactives/collections.py
+++ b/reactives/collections.py
@@ -2,26 +2,30 @@ from __future__ import annotations
 
 import copy
 from contextlib import suppress
-from typing import Any, Iterable
-
-try:
-    from typing import SupportsIndex  # type: ignore
-except ImportError:
-    from typing_extensions import SupportsIndex
+from typing import Any, Iterable, TypeVar, Generic, Optional, overload, Iterator, List, cast, Dict, SupportsIndex
 
 from reactives import scope
 from reactives.factory import Reactive
 from reactives.reactor import ReactorController
 
+try:
+    from typing import Self  # type: ignore
+except ImportError:
+    from typing_extensions import Self
 
-class ReactiveDict(dict, Reactive):
+T = TypeVar('T')
+KeyT = TypeVar('KeyT')
+ValueT = TypeVar('ValueT')
+
+
+class ReactiveDict(Dict[KeyT, ValueT], Reactive, Generic[KeyT, ValueT]):
     def __init__(self, *args, **kwargs):
         self.react = ReactorController()
         super().__init__(*args, **kwargs)
         for value in dict.values(self):
             self._wire(value)
 
-    def __copy__(self) -> ReactiveDict:
+    def __copy__(self) -> Self:
         copied = self.__class__(self)
         copied.react = ReactorController()
         copied.react.react(*self.react.reactors)
@@ -65,7 +69,15 @@ class ReactiveDict(dict, Reactive):
         self.react.trigger()
         return key, value
 
-    def setdefault(self, key, value):
+    @overload
+    def setdefault(self, key: KeyT) -> Optional[ValueT]:
+        pass
+
+    @overload
+    def setdefault(self, key: KeyT, value: ValueT) -> ValueT:
+        pass
+
+    def setdefault(self, key: KeyT, value: Optional[ValueT] = None) -> Optional[ValueT]:
         try:
             return self[key]
         except KeyError:
@@ -114,12 +126,9 @@ class ReactiveDict(dict, Reactive):
     def __ne__(self, other):
         return super().__ne__(other)
 
-    # dict.__reversed__() was added in Python 3.8.
-    if hasattr(dict, '__reversed__'):
-        @scope.register_self
-        def __reversed__(self):
-            # Mypy cannot tell we're only calling the parent method in Python >=3.8, so we have to suppress errors.
-            return super().__reversed__()  # type: ignore
+    @scope.register_self
+    def __reversed__(self):
+        return super().__reversed__()
 
     def __setitem__(self, key, value):
         super().__setitem__(key, value)
@@ -133,35 +142,35 @@ class ReactiveDict(dict, Reactive):
         return super().__sizeof__()
 
 
-class ReactiveList(list, Reactive):
+class ReactiveList(List[ValueT], Reactive):
     def __init__(self, *args, **kwargs):
         self.react = ReactorController()
         super().__init__(*args, **kwargs)
-        for value in list.__iter__(self):
-            self._wire(value)
+        self._wire(*list.__iter__(self))
 
-    def __copy__(self) -> ReactiveList:
+    def __copy__(self) -> Self:
         copied = self.__class__(self)
         scope.register(copied)
         copied.react = copy.copy(self.react)
         return copied
 
-    def _wire(self, value) -> None:
-        if isinstance(value, Reactive):
-            value.react(self)
+    def _wire(self, *values: ValueT) -> None:
+        for value in values:
+            if isinstance(value, Reactive):
+                value.react(self)
 
-    def _unwire(self, value) -> None:
-        if isinstance(value, Reactive):
-            value.react.shutdown(self)
+    def _unwire(self, *values: ValueT) -> None:
+        for value in values:
+            if isinstance(value, Reactive):
+                value.react.shutdown(self)
 
-    def append(self, value) -> None:
+    def append(self, value: ValueT) -> None:
         super().append(value)
         self._wire(value)
         self.react.trigger()
 
     def clear(self) -> None:
-        for value in list.__iter__(self):
-            self._unwire(value)
+        self._unwire(*list.__iter__(self))
         super().clear()
         self.react.trigger()
 
@@ -170,10 +179,10 @@ class ReactiveList(list, Reactive):
         return copy.copy(self)
 
     @scope.register_self
-    def count(self, value) -> int:
+    def count(self, value: ValueT) -> int:
         return super().count(value)
 
-    def extend(self, other: Iterable) -> None:
+    def extend(self, other: Iterable[ValueT]) -> None:
         for value in other:
             super().append(value)
             self._wire(value)
@@ -182,21 +191,21 @@ class ReactiveList(list, Reactive):
             self.react.trigger()
 
     @scope.register_self
-    def index(self, value, *args, **kwargs) -> int:
+    def index(self, value: ValueT, *args, **kwargs) -> int:
         return super().index(value, *args, **kwargs)
 
-    def insert(self, index: SupportsIndex, value: Any) -> None:
+    def insert(self, index: SupportsIndex, value: ValueT) -> None:
         super().insert(index, value)
         self._wire(value)
         self.react.trigger()
 
-    def pop(self, *args, **kwargs) -> Any:
+    def pop(self, *args, **kwargs) -> ValueT:
         value = super().pop(*args, **kwargs)
         self._unwire(value)
         self.react.trigger()
         return value
 
-    def remove(self, value) -> None:
+    def remove(self, value: ValueT) -> None:
         super().remove(value)
         self._unwire(value)
         self.react.trigger()
@@ -209,29 +218,43 @@ class ReactiveList(list, Reactive):
         super().sort(*args, **kwargs)
         self.react.trigger()
 
-    def __add__(self, other):
+    @overload
+    def __add__(self, other: List[ValueT]) -> Self:
+        pass
+
+    @overload
+    def __add__(self, other: List[T]) -> ReactiveList[ValueT | T]:
+        pass
+
+    def __add__(  # type: ignore
+        self,
+        other: List[ValueT] | List[T],
+    ) -> Self | ReactiveList[ValueT | T]:
         return ReactiveList(super().__add__(other))
 
     @scope.register_self
-    def __contains__(self, value) -> bool:
+    def __contains__(self, value: Any) -> bool:
         return super().__contains__(value)
 
-    def __delitem__(self, index) -> None:
+    def __delitem__(self, index: SupportsIndex | slice) -> None:
         with suppress(IndexError):
-            self._unwire(super().__getitem__(index))
+            if isinstance(index, slice):
+                self._unwire(*super().__getitem__(index))
+            else:
+                self._unwire(super().__getitem__(index))
         super().__delitem__(index)
         self.react.trigger()
 
     @scope.register_self
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: Any) -> bool:
         return super().__eq__(other)
 
     @scope.register_self
-    def __getitem__(self, index) -> Any:
+    def __getitem__(self, index: SupportsIndex) -> Any:
         return super().__getitem__(index)
 
     @scope.register_self
-    def __iadd__(self, other: Iterable) -> ReactiveList:
+    def __iadd__(self, other: Iterable[ValueT]) -> Self:
         for value in other:
             super().append(value)
             self._wire(value)
@@ -240,41 +263,51 @@ class ReactiveList(list, Reactive):
 
     @scope.register_self
     def __imul__(self, other) -> ReactiveList:
-        for value in list.__iter__(self):
-            self._unwire(value)
+        self._unwire(*list.__iter__(self))
         super().__imul__(other)
-        for value in list.__iter__(self):
-            self._wire(value)
+        self._wire(*list.__iter__(self))
         self.react.trigger()
         return self
 
     @scope.register_self
-    def __iter__(self):
+    def __iter__(self) -> Iterator[ValueT]:
         return super().__iter__()
 
     @scope.register_self
-    def __len__(self):
+    def __len__(self) -> int:
         return super().__len__()
 
-    def __mul__(self, other):
-        return ReactiveList(super().__mul__(other))
+    def __mul__(self, other: SupportsIndex) -> Self:
+        return type(self)(super().__mul__(other))
 
     @scope.register_self
-    def __ne__(self, other):
+    def __ne__(self, other: Any) -> bool:
         return super().__ne__(other)
 
     @scope.register_self
-    def __reversed__(self):
-        return super().__reversed__()
+    def __reversed__(self) -> Self:
+        return type(self)(super().__reversed__())
 
-    def __rmul__(self, other):
-        return ReactiveList(super().__rmul__(other))
+    def __rmul__(self, other: SupportsIndex) -> Self:
+        return type(self)(super().__rmul__(other))
 
-    def __setitem__(self, index, value):
-        super().__setitem__(index, value)
-        self._wire(value)
+    @overload
+    def __setitem__(self, index: SupportsIndex, value: ValueT) -> None:
+        pass
+
+    @overload
+    def __setitem__(self, index: slice, value: Iterable[ValueT]) -> None:
+        pass
+
+    def __setitem__(self, index: SupportsIndex | slice, value: ValueT | Iterable[ValueT]) -> None:
+        if isinstance(index, slice):
+            super().__setitem__(index, cast(Iterable[ValueT], value))
+            self._wire(*cast(Iterable[ValueT], value))
+        else:
+            super().__setitem__(index, cast(ValueT, value))
+            self._wire(cast(ValueT, value))
         self.react.trigger()
 
     @scope.register_self
-    def __sizeof__(self):
+    def __sizeof__(self) -> int:
         return super().__sizeof__()

--- a/reactives/factory/function.py
+++ b/reactives/factory/function.py
@@ -3,16 +3,15 @@ from __future__ import annotations
 import functools
 from typing import Callable, Optional, Dict, Any, cast
 
-try:
-    from typing import Self  # type: ignore
-except ImportError:
-    from typing_extensions import Self  # type: ignore
-
-
 from reactives import scope
 from reactives.factory import reactive_factory, Reactive
 from reactives.factory.type import InstanceAttribute, ReactiveInstance
 from reactives.reactor import ReactorController
+
+try:
+    from typing import Self  # type: ignore
+except ImportError:
+    from typing_extensions import Self
 
 
 class _FunctionReactorController(ReactorController):

--- a/reactives/factory/property.py
+++ b/reactives/factory/property.py
@@ -1,15 +1,15 @@
 import functools
 from typing import Any, Dict, Callable, Optional, TypeVar
 
-try:
-    from typing import Self  # type: ignore
-except ImportError:
-    from typing_extensions import Self  # type: ignore
-
 from reactives import scope
 from reactives.factory import reactive_factory, UnsupportedReactive, Reactive, reactive
 from reactives.factory.type import InstanceAttribute, ReactiveInstance
 from reactives.reactor import ReactorController
+
+try:
+    from typing import Self  # type: ignore
+except ImportError:
+    from typing_extensions import Self
 
 T = TypeVar('T')
 

--- a/reactives/factory/type.py
+++ b/reactives/factory/type.py
@@ -5,13 +5,13 @@ from contextlib import suppress
 from typing import Dict, Any, Type
 from warnings import warn
 
+from reactives.factory import reactive_factory, Reactive
+from reactives.reactor import ReactorController
+
 try:
     from typing import Self  # type: ignore
 except ImportError:
-    from typing_extensions import Self  # type: ignore
-
-from reactives.factory import reactive_factory, Reactive
-from reactives.reactor import ReactorController
+    from typing_extensions import Self
 
 
 class InstanceAttribute:

--- a/reactives/reactor.py
+++ b/reactives/reactor.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import copy
 import inspect
 import weakref
@@ -6,17 +7,17 @@ from collections import deque
 from contextlib import contextmanager, suppress
 from typing import Sequence, Tuple, Optional, Dict, Set, Any, Iterator, cast, Callable, Union, List
 
-try:
-    from typing import Self  # type: ignore
-except ImportError:
-    from typing_extensions import Self  # type: ignore
-
 from reactives.factory import Reactive
 
 try:
     from graphlib import TopologicalSorter
 except ImportError:
     from graphlib_backport import TopologicalSorter  # type: ignore
+
+try:
+    from typing import Self  # type: ignore
+except ImportError:
+    from typing_extensions import Self
 
 
 class ReactorController:

--- a/reactives/tests/factory/test_type.py
+++ b/reactives/tests/factory/test_type.py
@@ -8,6 +8,11 @@ from reactives.factory import reactive, Reactive
 from reactives.factory.type import _InstanceReactorController, ReactiveInstance
 from reactives.tests import assert_reactor_called, assert_not_reactor_called
 
+try:
+    from typing import Self  # type: ignore
+except ImportError:
+    from typing_extensions import Self
+
 
 class InstanceReactorControllerTest(TestCase):
     def test___copy__(self) -> None:
@@ -72,7 +77,7 @@ class ReactiveTypeTest(TestCase):
 
     @reactive
     class SubjectWithCopy(Subject):
-        def __copy__(self) -> ReactiveTypeTest.SubjectWithCopy:
+        def __copy__(self) -> Self:
             return self.__class__()
 
     def test_pickle(self) -> None:

--- a/setup.py
+++ b/setup.py
@@ -25,15 +25,16 @@ SETUP = {
     'classifiers': [
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
     ],
-    'python_requires': '~= 3.7',
+    'python_requires': '~= 3.8',
     'install_requires': [
-        'graphlib-backport ~= 1.0; python_version < "3.9"',
+        'graphlib-backport ~= 1.0.3; python_version < "3.9"',
+        'typing_extensions ~= 4.4.0; python_version < "3.11"',
     ],
     'extras_require': {
         'development': [
@@ -41,13 +42,13 @@ SETUP = {
             'codecov ~= 2.1.12',
             'coverage ~= 6.3.2',
             'dill ~= 0.3.4',
-            'flake8 ~= 4.0.1',
-            'mypy ~= 0.950',
+            'flake8 ~= 6.0.0',
+            # @todo Set this to ~= 0.992 (or whichever version comes after 0.991) once that version has been released.
+            'mypy @ git+https://github.com/python/mypy.git@96ac8b3e71c743b02ea4e3c84da0248659e40f82',
             'nose2 ~= 0.11.0',
             'parameterized ~= 0.8.1',
             'setuptools ~= 62.1.0',
             'twine ~= 4.0',
-            'typing_extensions ~= 4.2.0; python_version < "3.10"',
             'wheel ~= 0.37.1',
         ],
     },

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,11 @@
 [tox]
-envlist = py37, py38, py39, py310
+envlist = py38, py39, py310, py311
 skip_missing_interpreters = true
 
 [testenv]
 install_command = {toxinidir}/bin/build-dev {opts} {packages}
 commands = {toxinidir}/bin/test
 usedevelop = True
-
-[testenv:py37]
-basepython = python3.7
 
 [testenv:py38]
 basepython = python3.8
@@ -18,3 +15,6 @@ basepython = python3.9
 
 [testenv:py310]
 basepython = python3.10
+
+[testenv:py311]
+basepython = python3.11


### PR DESCRIPTION
This drops Python 3.7 support, because some of our dependencies dropped it as well in their releases that introduce 3.11 support.