### PR TITLE
Fix a bug that would prevent properties from being deleted on trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ apple.react['apple'].react.trigger()
 # >>> "The apple got triggered!"
 ```
 
-If a property *deleter* is present, it will be called automatically when the property is triggered:
+If a property *deleter* is present, it may be called automatically when the property is triggered:
 ```python
 from reactives.instance import ReactiveInstance
 from reactives.instance.property import reactive_property
@@ -106,7 +106,7 @@ class Apple(ReactiveInstance):
         self._cached_something = None
 
     @property
-    @reactive_property
+    @reactive_property(on_trigger_delete=True)
     def apple(self) -> str:
         if self._cached_something is None:
             self._cached_something = 'I got you something!'
@@ -122,35 +122,6 @@ print(apple.apple)
 apple.react['apple'].react.trigger()
 print(apple.apple)
 # >>> "I got you nothing!"
-```
-
-If you do not want automatic deletion, configure the property's `@reactive` decorator as such:
-```python
-from reactives.instance import ReactiveInstance
-from reactives.instance.property import OnTriggerDelete, reactive_property
-
-class Apple(ReactiveInstance):
-    def __init__(self):
-        super().__init__()
-        self._cached_something = None
-
-    @property
-    @reactive_property(on_trigger_delete=OnTriggerDelete.NO_DELETE)
-    def apple(self) -> str:
-        if self._cached_something is None:
-            self._cached_something = 'I got you something!'
-        return self._cached_something
-
-    @apple.deleter
-    def apple(self)  -> None:
-        self._cached_something = 'I got you nothing!'
-
-apple = Apple()
-print(apple.apple)
-# >>> "I got you something!"
-apple.react['apple'].react.trigger()
-print(apple.apple)
-# >>> "I got you something!"
 ```
 
 Property *setters* work exactly like with any other `property`:

--- a/reactives/_callable.py
+++ b/reactives/_callable.py
@@ -43,7 +43,7 @@ class CallableDefinition(Generic[ParamT, ReturnT]):
         self.callable = _callable
         self.on_trigger_call = on_trigger_call
 
-    def _call(self, reactive_attribute: Reactive, *args: ParamT.args, **kwargs: ParamT.kwargs) -> ReturnT:
-        scope.register(reactive_attribute)
-        with scope.collect(reactive_attribute):
+    def _call(self, reactive_callable: Reactive, *args: ParamT.args, **kwargs: ParamT.kwargs) -> ReturnT:
+        scope.register(reactive_callable)
+        with scope.collect(reactive_callable):
             return self.callable(*args, **kwargs)

--- a/reactives/reactor.py
+++ b/reactives/reactor.py
@@ -244,7 +244,7 @@ ExpectedCallCount = Union[int, Tuple[int, int], Tuple[int, None], Tuple[None, in
 
 
 class AssertCallCountReactor:
-    def __init__(self, expected_call_count: ExpectedCallCount):
+    def __init__(self, reactor_controller: ReactorController, expected_call_count: ExpectedCallCount = 1):
         self._exact_expected_call_count: int | None
         self._minimum_expected_call_count: int | None
         self._maximum_expected_call_count: int | None
@@ -256,6 +256,10 @@ class AssertCallCountReactor:
             self._exact_expected_call_count = None
             self._minimum_expected_call_count, self._maximum_expected_call_count = expected_call_count
         self._actual_call_count = 0
+        self._reactor_controller = reactor_controller
+
+    def __repr__(self) -> str:
+        return f'<{self.__class__.__module__}.{self.__class__.__qualname__} object at {hex(id(self))} for {repr(self._reactor_controller)}>'
 
     def __call__(self) -> None:
         self._actual_call_count += 1

--- a/reactives/tests/instance/test_method.py
+++ b/reactives/tests/instance/test_method.py
@@ -5,20 +5,20 @@ from reactives.tests import assert_reactor_called, assert_not_reactor_called
 
 
 @reactive_function
-def dependency() -> None:
+def dependency_one() -> None:
+    dependency_two()
+
+
+@reactive_function
+def dependency_two() -> None:
     pass
 
 
 class Subject(ReactiveInstance):
-    def __init__(self) -> None:
-        super().__init__()
-        self.called = False
-
     @reactive_method
-    def subject(self) -> None:
-        if not self.called:
-            self.called = True
-            dependency()
+    def subject(self, call_dependency: bool) -> None:
+        if call_dependency:
+            dependency_one()
 
 
 class SubjectWithOnTriggerCall(ReactiveInstance):
@@ -44,29 +44,57 @@ class TestReactiveMethod:
 
     def test_call_as_class_method(self) -> None:
         subject = Subject()
-        # Call the reactive for the first time. This should result in dependency() being autowired.
-        Subject.subject(subject)
-        # dependency() being autowired should cause the reactor to be called.
-        with assert_reactor_called(subject):
-            dependency.react.trigger()
+
+        # Call the reactive for the first time. This should result in dependency_one() being autowired to
+        # subject.subject()
+        Subject.subject(subject, True)
+
+        # dependency_one() being autowired to subject.subject() should cause subject.subject() to be triggered.
+        with assert_reactor_called(subject.react['subject']):
+            dependency_one.react.trigger()
+
+        # dependency_two() being autowired to dependency_one() should cause subject.subject() and dependency_one() to be
+        # triggered.
+        with assert_reactor_called(subject.react['subject']):
+            with assert_reactor_called(dependency_one):
+                dependency_two.react.trigger()
+
+        # Ensure that dependencies are only added to the direct calling scope, and not to ancestors' scopes.
+        assert dependency_one.react in list(dependency_two.react._reactors)
+
         # Call the reactive again. This should result in dependency() being ignored and not to be autowired again.
-        Subject.subject(subject)
-        # dependency() no longer being autowired should not cause the reactor to be called.
-        with assert_not_reactor_called(subject):
-            dependency.react.trigger()
+        Subject.subject(subject, False)
+
+        # dependency_one() no longer being autowired should not cause subject.subject() to be triggered.
+        with assert_not_reactor_called(subject.react['subject']):
+            dependency_one.react.trigger()
 
     def test_call_as_instance_method(self) -> None:
         subject = Subject()
-        # Call the reactive for the first time. This should result in dependency() being autowired.
-        subject.subject()
-        # dependency() being autowired should cause the reactor to be called.
-        with assert_reactor_called(subject):
-            dependency.react.trigger()
+
+        # Call the reactive for the first time. This should result in dependency_one() being autowired to
+        # subject.subject()
+        subject.subject(True)
+
+        # dependency_one() being autowired to subject.subject() should cause subject.subject() to be triggered.
+        with assert_reactor_called(subject.react['subject']):
+            dependency_one.react.trigger()
+
+        # dependency_two() being autowired to dependency_one() should cause subject.subject() and dependency_one() to be
+        # triggered.
+        with assert_reactor_called(subject.react['subject']):
+            with assert_reactor_called(dependency_one):
+                dependency_two.react.trigger()
+
+        # Ensure that dependencies are only added to the direct calling scope, and not to ancestors' scopes.
+        assert dependency_one.react in list(dependency_two.react._reactors)
+
         # Call the reactive again. This should result in dependency() being ignored and not to be autowired again.
-        subject.subject()
-        # dependency() no longer being autowired should not cause the reactor to be called.
-        with assert_not_reactor_called(subject):
-            dependency.react.trigger()
+        subject.subject(False)
+
+        # dependency_one() no longer being autowired should not cause subject.subject() to be triggered.
+        with assert_not_reactor_called(subject.react['subject']):
+            dependency_one.react.trigger()
 
     def test_on_trigger_call(self) -> None:
         subject = SubjectWithOnTriggerCall()

--- a/reactives/tests/test_function.py
+++ b/reactives/tests/test_function.py
@@ -3,13 +3,19 @@ from reactives.tests import assert_reactor_called, assert_not_reactor_called
 
 
 @reactive_function
-def dependency() -> None:
+def dependency_one() -> None:
+    dependency_two()
+
+
+@reactive_function
+def dependency_two() -> None:
     pass
 
 
 @reactive_function
-def subject() -> None:
-    pass
+def subject(call_dependency: bool) -> None:
+    if call_dependency:
+        dependency_one()
 
 
 _on_trigger_calls = 0
@@ -28,25 +34,28 @@ class TestReactiveFunction:
         assert 'subject' == subject.__qualname__
 
     def test_call(self) -> None:
-        called = False
+        # Call the reactive for the first time. This should result in dependency_one() being autowired to subject().
+        subject(True)
 
-        @reactive_function
-        def subject() -> None:
-            nonlocal called
-            if not called:
-                called = True
-                dependency()
-
-        # Call the reactive for the first time. This should result in dependency() being autowired.
-        subject()
-        # dependency() being autowired should cause the reactor to be called.
+        # dependency_one() being autowired to subject() should cause subject() to be triggered.
         with assert_reactor_called(subject):
-            dependency.react.trigger()
-        # Call the reactive again. This should result in dependency() being ignored and not to be autowired again.
-        subject()
-        # dependency() no longer being autowired should not cause the reactor to be called.
+            dependency_one.react.trigger()
+
+        # dependency_two() being autowired to dependency_one() should cause subject() and dependency_one() to be
+        # triggered.
+        with assert_reactor_called(subject):
+            with assert_reactor_called(dependency_one):
+                dependency_two.react.trigger()
+
+        # Ensure that dependencies are only added to the direct calling scope, and not to ancestors' scopes.
+        assert dependency_one.react in list(dependency_two.react._reactors)
+
+        # Call the reactive again. This should result in dependency_*() being ignored and not to be autowired again.
+        subject(False)
+        # dependency_one() and dependency_two() no longer being autowired should not cause subject() to be triggered().
         with assert_not_reactor_called(subject):
-            dependency.react.trigger()
+            dependency_one.react.trigger()
+            dependency_two.react.trigger()
 
     def test_on_trigger_call(self) -> None:
         global _on_trigger_calls


### PR DESCRIPTION
## BC Breaks
- This removes the ability to **automatically** call a property's deleter when that property is triggered, as it was too prone to errors.